### PR TITLE
Add ECS Fargate infrastructure setup and demo data insertion script

### DIFF
--- a/.github/workflows/ecr-deploy-stg.yml
+++ b/.github/workflows/ecr-deploy-stg.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - stg
+  workflow_dispatch:
 
 env:
   AWS_REGION: ${{ secrets.AWS_REGION }}
@@ -12,7 +13,8 @@ env:
 jobs:
   # AWS 認証 & ECR ログイン
   ecr-login:
-    environment: Production
+    needs: infra-setup
+    environment: Preview
     runs-on: ubuntu-latest
     outputs:
       login: ${{ steps.login-ecr.outcome }}
@@ -34,7 +36,7 @@ jobs:
   # Backend STG イメージのビルド & プッシュ
   build-push-backend-stg:
     needs: ecr-login
-    environment: Production
+    environment: Preview
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
@@ -55,7 +57,7 @@ jobs:
   # Frontend STG イメージのビルド & プッシュ
   build-push-frontend-stg:
     needs: ecr-login
-    environment: Production
+    environment: Preview
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
@@ -71,4 +73,73 @@ jobs:
 
       - name: Push STG frontend to ECR
         run: |
-          docker push ${{ env.ECR_REGISTRY }}/front:stg 
+          docker push ${{ env.ECR_REGISTRY }}/front:stg
+
+  # DB migration on ECS
+  run-db-migrations:
+    needs: build-push-backend-stg
+    environment: Preview
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v2
+        with:
+          aws-access-key-id:     ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region:            ${{ env.AWS_REGION }}
+
+      - name: Run DB migrations on ECS
+        run: |
+          aws ecs run-task \
+            --cluster smartao-api-stg \
+            --launch-type FARGATE \
+            --task-definition backend-stg \
+            --network-configuration "awsvpcConfiguration={subnets=[${{ secrets.STG_SUBNETS }}],securityGroups=[${{ secrets.STG_SECURITY_GROUPS }}],assignPublicIp=DISABLED}" \
+            --overrides '{"containerOverrides":[{"name":"backend","command":["alembic","upgrade","head"]}]}'
+
+  deploy-backend-stg:
+    needs: run-db-migrations
+    environment: Preview
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v2
+        with:
+          aws-access-key-id:     ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region:            ${{ env.AWS_REGION }}
+      - name: Deploy Backend to ECS
+        uses: aws-actions/amazon-ecs-deploy-task-definition@v1
+        with:
+          aws-region: ${{ env.AWS_REGION }}
+          cluster: smartao-api-stg
+          service: smartao-api-stg-service
+          task-definition: ECS/backend-task-def-stg.json
+          wait-for-service-stability: true
+
+  deploy-frontend-stg:
+    needs: build-push-frontend-stg
+    environment: Preview
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v2
+        with:
+          aws-access-key-id:     ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region:            ${{ env.AWS_REGION }}
+      - name: Deploy Frontend to ECS
+        uses: aws-actions/amazon-ecs-deploy-task-definition@v1
+        with:
+          aws-region: ${{ env.AWS_REGION }}
+          cluster: smartao-front-stg
+          service: smartao-front-stg-service
+          task-definition: ECS/frontend-task-def-stg.json
+          wait-for-service-stability: true 

--- a/.github/workflows/infra-setup.yml
+++ b/.github/workflows/infra-setup.yml
@@ -1,0 +1,42 @@
+name: STG Terraform Infra Setup
+
+on:
+  workflow_dispatch:
+
+env:
+  AWS_REGION: ${{ secrets.AWS_REGION }}
+
+jobs:
+  terraform:
+    runs-on: ubuntu-latest
+    environment: Preview
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v2
+        with:
+          aws-access-key-id:     ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region:            ${{ env.AWS_REGION }}
+
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v1
+        with:
+          terraform_version: '1.5.0'
+
+      - name: Terraform Init
+        working-directory: infrastructure/terraform
+        run: terraform init -input=false
+
+      - name: Terraform Plan
+        working-directory: infrastructure/terraform
+        run: terraform plan -input=false -out=tfplan
+
+      - name: Terraform Apply
+        working-directory: infrastructure/terraform
+        env:
+          TF_VAR_db_password:   ${{ secrets.DB_PASSWORD }}
+          TF_VAR_api_base_url:  ${{ secrets.API_BASE_URL }}
+        run: terraform apply -input=false -auto-approve tfplan 

--- a/ECS/backend-task-def-stg.json
+++ b/ECS/backend-task-def-stg.json
@@ -1,0 +1,38 @@
+{
+  "family": "backend-stg",
+  "networkMode": "awsvpc",
+  "requiresCompatibilities": ["FARGATE"],
+  "cpu": "256",
+  "memory": "512",
+  "executionRoleArn": "arn:aws:iam::123456789012:role/ecsTaskExecutionRole",
+  "containerDefinitions": [
+    {
+      "name": "backend",
+      "image": "123456789012.dkr.ecr.ap-northeast-1.amazonaws.com/api:stg",
+      "portMappings": [
+        { "containerPort": 5050, "protocol": "tcp" }
+      ],
+      "logConfiguration": {
+        "logDriver": "awslogs",
+        "options": {
+          "awslogs-group": "/ecs/backend-stg",
+          "awslogs-region": "ap-northeast-1",
+          "awslogs-stream-prefix": "ecs"
+        }
+      },
+      "environment": [
+        { "name": "PORT", "value": "5050" }
+      ],
+      "secrets": [
+        { "name": "DATABASE_URL", "valueFrom": "arn:aws:secretsmanager:ap-northeast-1:123456789012:secret:stg/backend/env:DATABASE_URL::" },
+        { "name": "OPENAI_API_KEY", "valueFrom": "arn:aws:secretsmanager:ap-northeast-1:123456789012:secret:stg/backend/env:OPENAI_API_KEY::" },
+        { "name": "SECRET_KEY", "valueFrom": "arn:aws:secretsmanager:ap-northeast-1:123456789012:secret:stg/backend/env:SECRET_KEY::" },
+        { "name": "STRIPE_SECRET_KEY", "valueFrom": "arn:aws:secretsmanager:ap-northeast-1:123456789012:secret:stg/backend/env:STRIPE_SECRET_KEY::" },
+        { "name": "STRIPE_PUBLISHABLE_KEY", "valueFrom": "arn:aws:secretsmanager:ap-northeast-1:123456789012:secret:stg/backend/env:STRIPE_PUBLISHABLE_KEY::" },
+        { "name": "STRIPE_WEBHOOK_SECRET", "valueFrom": "arn:aws:secretsmanager:ap-northeast-1:123456789012:secret:stg/backend/env:STRIPE_WEBHOOK_SECRET::" },
+        { "name": "NEXTAUTH_URL", "valueFrom": "arn:aws:secretsmanager:ap-northeast-1:123456789012:secret:stg/backend/env:NEXTAUTH_URL::" },
+        { "name": "AUTH_SECRET", "valueFrom": "arn:aws:secretsmanager:ap-northeast-1:123456789012:secret:stg/backend/env:AUTH_SECRET::" }
+      ]
+    }
+  ]
+} 

--- a/ECS/frontend-task-def-stg.json
+++ b/ECS/frontend-task-def-stg.json
@@ -1,0 +1,37 @@
+{
+  "family": "frontend-stg",
+  "networkMode": "awsvpc",
+  "requiresCompatibilities": ["FARGATE"],
+  "cpu": "256",
+  "memory": "512",
+  "executionRoleArn": "arn:aws:iam::123456789012:role/ecsTaskExecutionRole",
+  "containerDefinitions": [
+    {
+      "name": "frontend",
+      "image": "123456789012.dkr.ecr.ap-northeast-1.amazonaws.com/front:stg",
+      "portMappings": [
+        { "containerPort": 3000, "protocol": "tcp" }
+      ],
+      "logConfiguration": {
+        "logDriver": "awslogs",
+        "options": {
+          "awslogs-group": "/ecs/frontend-stg",
+          "awslogs-region": "ap-northeast-1",
+          "awslogs-stream-prefix": "ecs"
+        }
+      },
+      "environment": [
+        { "name": "NEXT_PUBLIC_API_BASE_URL", "value": "https://stg-api.smartao.com" },
+        { "name": "NEXT_PUBLIC_BROWSER_API_URL", "value": "https://stg-api.smartao.com" },
+        { "name": "NEXTAUTH_URL", "value": "https://stg.smartao.com" },
+        { "name": "NEXTAUTH_COOKIE_DOMAIN", "value": "stg.smartao.com" }
+      ],
+      "secrets": [
+        {
+          "name": "AUTH_SECRET",
+          "valueFrom": "arn:aws:secretsmanager:ap-northeast-1:123456789012:secret:stg/frontend/env:AUTH_SECRET::"
+        }
+      ]
+    }
+  ]
+} 

--- a/README.md
+++ b/README.md
@@ -43,3 +43,50 @@
    docker-compose up -d
    ```
 
+## ECS でのデモデータ挿入
+
+Docker 上ではなく、ECS Fargate 上のコンテナで一度だけデモデータを挿入するには、ECS Exec 機能を使います。以下の手順を README に追記します。
+
+1. **Execute Command の有効化**
+   ```bash
+   aws ecs update-service \
+     --cluster smartao-api-stg \
+     --service smartao-api-stg-service \
+     --enable-execute-command \
+     --region <your-region>
+   ```
+   - `smartao-api-stg` はバックエンドのクラスター名、`smartao-api-stg-service` はサービス名です。
+
+2. **IAM 権限の確認**
+   - タスク実行ロール (`ecsTaskExecutionRole`) に以下のポリシーをアタッチ:
+     - `AmazonECSTaskExecutionRolePolicy`
+     - `AmazonSSMManagedInstanceCore`
+   - 操作ユーザーの IAM (CLI 実行者) に:
+     - `ecs:ExecuteCommand`
+     - SSM Session Manager 関連ポリシー (`ssm:StartSession`, `ssm:SendCommand` など)
+     - CloudWatch Logs 書き込み権限
+
+3. **タスク ARN を取得（タスクが稼働中であること）**
+   ```bash
+   aws ecs list-tasks \
+     --cluster smartao-api-stg \
+     --service-name smartao-api-stg-service \
+     --region <your-region> \
+     --query 'taskArns[0]' --output text
+   ```
+
+4. **Execute Command でシードスクリプトを実行**
+   ```bash
+   aws ecs execute-command \
+     --cluster smartao-api-stg \
+     --task <TASK_ARN> \
+     --container backend \
+     --interactive \
+     --command "python scripts/seed_demo_data.py" \
+     --region <your-region>
+   ```
+   - `scripts/seed_demo_data.py` は `backend/scripts/` に作成した初回デモデータ挿入スクリプトです。  
+   - 実行後、デモデータが挿入され、CloudWatch Logs にも出力されます。
+
+以上の手順で、ECS Fargate 上のコンテナに手を触れずに一時的にデータ挿入が可能です。
+

--- a/architecture/InfraSTGSetUp.md
+++ b/architecture/InfraSTGSetUp.md
@@ -1,0 +1,121 @@
+# STG 環境 インフラセットアップ手順
+
+このドキュメントでは、ステージング（STG）環境のインフラをゼロから構築する手順をまとめています。
+
+---
+
+## 前提条件
+1. AWS CLI v2 がインストールされ、`aws configure` で認証情報が設定済み
+2. Terraform 1.5.0 以上がインストール済み
+3. GitHub リポジトリに以下のシークレットが登録済み
+   - `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY`
+   - `AWS_REGION` (例: `ap-northeast-1`)
+   - `AWS_ECR_REGISTRY` (例: `123456789012.dkr.ecr.ap-northeast-1.amazonaws.com`)
+   - `DB_PASSWORD` （RDS マスターDBのパスワード）
+   - `API_BASE_URL` （例: `https://stg-api.smartao.com`）
+   - `STG_SUBNETS`（サブネットIDカンマ区切り）
+   - `STG_SECURITY_GROUPS`（セキュリティグループIDカンマ区切り）
+
+---
+
+## 0. 環境変数の設定
+本手順で利用する環境変数・シークレットと管理方法は以下のとおりです。
+
+### GitHub シークレット
+- AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY  : AWS認証情報
+- AWS_REGION                           : AWSリージョン (例: ap-northeast-1)
+- AWS_ECR_REGISTRY                     : ECRレジストリURI
+- DB_PASSWORD                          : RDS マスターDBのパスワード
+- API_BASE_URL                         : フロントエンドが利用するAPIのベースURL (例: https://stg-api.smartao.com)
+- STG_SUBNETS                          : Terraform で作成するサブネットIDをカンマ区切りで指定
+- STG_SECURITY_GROUPS                  : Terraform で作成するセキュリティグループIDをカンマ区切りで指定
+
+### Terraform 変数（TF_VAR）
+- TF_VAR_db_password   = DB_PASSWORD と同じ値を参照
+- TF_VAR_api_base_url  = API_BASE_URL と同じ値を参照
+
+### コンテナ環境変数注入
+- **バックエンド（ECS Task）**: Secrets Manager に登録した `backend/env` シークレットを `aws_ecs_task_definition` の `secrets` で注入
+- **フロントエンド（ECS Task）**: SSM Parameter Store の `/stg/api-base-url` を `environment` で注入
+- Docker Compose ローカル開発用には `backend/.env.stg` および `study-support-app/.env.stg` を参照
+
+---
+
+## 1. リポジトリのクローン
+```bash
+git clone <repository-url>
+cd react_ai_chatapp
+```
+
+---
+
+## 2. Terraform 変数の設定
+1. `infrastructure/terraform`ディレクトリへ移動
+   ```bash
+   cd infrastructure/terraform
+   ```
+2. 変数ファイルの準備
+   - `terraform.tfvars` を作成し、以下を記載
+     ```hcl
+     db_password    = "<RDS マスターDB パスワード>"
+     api_base_url   = "https://stg-api.smartao.com"
+     ```
+   - または、環境変数としてエクスポート
+     ```bash
+     export TF_VAR_db_password="<RDS パスワード>"
+     export TF_VAR_api_base_url="https://stg-api.smartao.com"
+     ```
+
+---
+
+## 3. STG インフラ構築 (Terraform)
+### GitHub Actions から実行
+1. GitHub 上の **Actions** タブ → **STG Terraform Infra Setup** ワークフローを選択
+2. 「Run workflow」を押し、必要に応じて入力フォームからブランチやシークレットを確認
+3. 実行後、以下のリソースが無料枠中心で作成されます:
+   - VPC / Public・Private サブネット
+   - セキュリティグループ (アプリ用 / RDS用)
+   - ALB (フロント / バックエンド) とターゲットグループ・HTTPリスナー
+   - ECR リポジトリ (backend, frontend)
+   - ECS クラスター
+   - RDS for PostgreSQL (db.t3.micro / 20GB)
+   - SSM Parameter Store, Secrets Manager
+
+### CLI から実行
+```bash
+cd infrastructure/terraform
+terraform init -input=false
+terraform plan -input=false -out=tfplan
+terraform apply -input=false -auto-approve tfplan
+```
+
+---
+
+## 4. DNS（Cloudflare）設定
+1. Cloudflare ダッシュボード → 対象ドメインの **DNS** ページを開く
+2. **CNAME レコード** を追加
+   - フロントエンド  
+     - **Name**: `stg`（`stg.smartao.com`）  
+     - **Target**: フロント ALB の DNS 名  
+   - バックエンド  
+     - **Name**: `stg-api`（`stg-api.smartao.com`）  
+     - **Target**: バックエンド ALB の DNS 名  
+3. TTL: Auto, Proxy status: お好みで (DNS only / Proxied)
+
+---
+
+## 5. アプリケーションデプロイ (STG)
+1. `stg` ブランチへコードをプッシュ
+2. GitHub Actions の `Build & Push STG Docker Images to ECR` が自動実行
+   - Docker イメージのビルド & ECR プッシュ
+   - ECS タスク定義更新 & サービスデプロイ
+   - DB マイグレーション (Fargate run-task により実行)
+
+---
+
+## 6. 確認方法
+- CloudWatch Logs で各サービスのログを確認
+- ALB のターゲットグループでヘルスチェックステータスを確認
+- ブラウザで `https://stg.smartao.com` や `https://stg-api.smartao.com` にアクセス
+
+以上でステージング環境のインフラ構築からアプリデプロイまでが完了します。

--- a/architecture/infra.md
+++ b/architecture/infra.md
@@ -1,0 +1,92 @@
+# インフラ構成 (AWS Free Tier 中心)
+
+以下は可能な限り無料利用枠のみで構成した例です。
+
+---
+
+## 1. リージョン
+- ap-northeast-1 (東京)
+
+## 2. VPC / ネットワーク
+- **VPC**: 1つの専用VPC
+- **サブネット**
+  - Public Subnet ×2 (Fargate タスクに直接割り当て、NAT Gateway不要)
+  - Private Subnet ×2 (RDS 配置用)
+- **セキュリティグループ**
+  - ALB / Fargate (HTTP/HTTPS)
+  - ECSタスク → RDS (PostgreSQL: 5432)
+
+## 2-1. Cloudflare での DNS 設定（手動）
+- Cloudflare ダッシュボードにログイン
+- 対象ドメイン（例: `smartao.com`）の **DNS** ページを開く
+- **CNAME レコードを追加 (frontend)**
+  - **Type**: CNAME
+  - **Name**: `stg`  （`stg.smartao.com`）
+  - **Target / Content**: フロントエンド ALB の DNS 名 (例: `smartao-front-stg-xxxxxx.elb.amazonaws.com`)
+  - **TTL**: Auto
+  - **Proxy status**: DNS only（オレンジ雲オフ） or Proxied（オレンジ雲オン）
+- **CNAME レコードを追加 (backend)**
+  - **Type**: CNAME
+  - **Name**: `stg-api`  （`stg-api.smartao.com`）
+  - **Target / Content**: バックエンド ALB の DNS 名 (例: `smartao-api-stg-yyyyyy.elb.amazonaws.com`)
+  - **TTL**: Auto
+  - **Proxy status**: DNS only（オレンジ雲オフ） or Proxied（オレンジ雲オン）
+- 保存後、数秒～数分で両サブドメインが ALB を経由して ECS Fargate に向くようになります。
+
+## 3. コンテナオーケストレーション (ECS Fargate)
+- **ECR**
+  - リポジトリ: `backend`, `frontend`
+  - 月500MBまで無料
+- **ECS クラスター**
+  - バックエンド: `smartao-api-stg`
+  - フロントエンド: `smartao-front-stg`
+- **サービス**
+  - `smartao-api-stg-service`, `smartao-front-stg-service`
+- **タスク定義**
+  - cpu: 256 / memory: 512
+  - networkMode: `awsvpc` / assignPublicIp: ENABLED
+- **ログ**
+  - CloudWatch Logs へ出力 (5GB/月まで無料)
+
+## 4. データベース (RDS for PostgreSQL)
+- インスタンスタイプ: db.t3.micro (無料枠)
+- ストレージ: 20GB General Purpose (gp2)
+- Multi-AZ: 無効 (コスト削減)
+- パラメータグループ: デフォルト
+- 接続: ECSタスクのセキュリティグループ経由
+
+## 5. メール送信 (SES)
+- **無料枠**: 月62,000通まで
+- ドメイン/メールアドレス検証済み
+- バウンス・苦情通知は SNS へ連携可能
+- アプリケーションから AWS SDK(v3) 経由で送信
+
+## 6. 設定管理 / シークレット管理
+- AWS Systems Manager Parameter Store (無料枠)
+  - 非機密環境変数の管理
+- AWS Secrets Manager
+  - DB接続情報やAPIキーなど機密情報を安全に注入
+
+## 7. SSL/TLS
+- AWS Certificate Manager で無料証明書発行
+- ALB または CloudFront へアタッチ
+
+## 8. CI/CD
+- GitHub Actions (無料枠)
+  - イメージビルド & ECR プッシュ
+  - ECS タスク定義更新 & サービスデプロイ
+  - DBマイグレーション & シードデータ導入
+
+## 9. 監視・アラート
+- CloudWatch Metrics (10メトリクスまで無料)
+- CloudWatch Logs Insights
+- 必要に応じて CloudWatch Alarm で通知
+
+## 10. コスト最適化
+- NAT Gateway は使用せず、パブリックIP直接割当
+- マルチAZ無効化
+- ストレージ & ログ量は無料枠内に収める
+
+---
+
+※ 本構成は小規模開発 / ステージング用途を想定し、AWS無料利用枠を最大限活用しています。

--- a/backend/Dockerfile.stg
+++ b/backend/Dockerfile.stg
@@ -16,8 +16,6 @@ RUN pip install --no-cache-dir --upgrade pip && \
 
 # アプリケーションコード・環境変数をコピー
 COPY . ./
-# STG環境用envファイルを読み込み
-COPY .env.stg .env
 
 # アプリケーションパスを設定
 ENV PYTHONPATH=/app

--- a/backend/scripts/seed.sh
+++ b/backend/scripts/seed.sh
@@ -1,4 +1,0 @@
-#!/bin/bash
-
-# シードデータを挿入
-python app/seeds/run_seeds.py

--- a/backend/scripts/seed_demo_data.py
+++ b/backend/scripts/seed_demo_data.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python3
+"""
+Initial demo data insertion script.
+Run this once to populate the database with demo seed data.
+"""
+import os
+import sys
+import logging
+from sqlalchemy.orm import Session
+
+# Ensure project root is in PYTHONPATH
+top_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
+if top_dir not in sys.path:
+    sys.path.append(top_dir)
+
+from app.database.database import SessionLocal
+from app.migrations.demo_data import insert_demo_data
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+def main():
+    logger.info("Starting initial demo data insertion...")
+    db: Session = SessionLocal()
+    try:
+        insert_demo_data(db)
+        db.commit()
+        logger.info("Demo data inserted successfully.")
+    except Exception as e:
+        logger.error(f"Error inserting demo data: {e}")
+        sys.exit(1)
+    finally:
+        db.close()
+
+if __name__ == "__main__":
+    main() 

--- a/infrastructure/terraform/iam.tf
+++ b/infrastructure/terraform/iam.tf
@@ -1,0 +1,26 @@
+data "aws_iam_policy_document" "ecs_task_assume_role" {
+  statement {
+    effect = "Allow"
+    principals {
+      type        = "Service"
+      identifiers = ["ecs-tasks.amazonaws.com"]
+    }
+    actions = ["sts:AssumeRole"]
+  }
+}
+
+resource "aws_iam_role" "ecs_task_execution_role" {
+  name               = "${var.environment}-ecs-task-exec-role"
+  assume_role_policy = data.aws_iam_policy_document.ecs_task_assume_role.json
+  tags = { Environment = var.environment }
+}
+
+resource "aws_iam_role_policy_attachment" "ecs_task_exec_policy" {
+  role       = aws_iam_role.ecs_task_execution_role.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy"
+}
+
+resource "aws_iam_role_policy_attachment" "ecs_ecr_pull_policy" {
+  role       = aws_iam_role.ecs_task_execution_role.name
+  policy_arn = "arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly"
+} 

--- a/infrastructure/terraform/main.tf
+++ b/infrastructure/terraform/main.tf
@@ -1,0 +1,197 @@
+terraform {
+  required_version = ">= 1.5.0"
+  required_providers {
+    aws      = { source = "hashicorp/aws",      version = "~> 5.0" }
+    external = { source = "hashicorp/external", version = "~> 2.1" }
+  }
+}
+
+provider "aws" {
+  region = var.aws_region
+}
+
+# VPC
+module "vpc" {
+  source  = "terraform-aws-modules/vpc/aws"
+  version = "~> 4.0"
+
+  name                 = "${var.environment}-vpc"
+  cidr                 = var.vpc_cidr
+  azs                  = var.azs
+  public_subnets       = var.public_subnets
+  private_subnets      = var.private_subnets
+  enable_nat_gateway   = false
+  enable_dns_hostnames = true
+
+  tags = { Environment = var.environment }
+}
+
+# セキュリティグループ: アプリケーション
+resource "aws_security_group" "app" {
+  name        = "${var.environment}-app-sg"
+  description = "Allow HTTP/3000/5050"
+  vpc_id      = module.vpc.vpc_id
+
+  ingress {
+    from_port   = 80
+    to_port     = 80
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+  ingress {
+    from_port   = 3000
+    to_port     = 3000
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+  ingress {
+    from_port   = 5050
+    to_port     = 5050
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = { Environment = var.environment }
+}
+
+# セキュリティグループ: RDS
+resource "aws_security_group" "rds" {
+  name        = "${var.environment}-rds-sg"
+  description = "Allow PostgreSQL"
+  vpc_id      = module.vpc.vpc_id
+
+  ingress {
+    from_port       = 5432
+    to_port         = 5432
+    protocol        = "tcp"
+    security_groups = [aws_security_group.app.id]
+  }
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = { Environment = var.environment }
+}
+
+# Application Load Balancer (Frontend)
+resource "aws_lb" "frontend" {
+  name               = "${var.environment}-front-alb"
+  internal           = false
+  load_balancer_type = "application"
+  subnets            = module.vpc.public_subnets
+  security_groups    = [aws_security_group.app.id]
+
+  tags = { Environment = var.environment }
+}
+
+resource "aws_lb_target_group" "frontend" {
+  name        = "${var.environment}-front-tg"
+  port        = 3000
+  protocol    = "HTTP"
+  vpc_id      = module.vpc.vpc_id
+  target_type = "ip"
+}
+
+resource "aws_lb_listener" "frontend_http" {
+  load_balancer_arn = aws_lb.frontend.arn
+  port              = 80
+  protocol          = "HTTP"
+
+  default_action {
+    type             = "forward"
+    target_group_arn = aws_lb_target_group.frontend.arn
+  }
+}
+
+# Application Load Balancer (Backend)
+resource "aws_lb" "backend" {
+  name               = "${var.environment}-api-alb"
+  internal           = false
+  load_balancer_type = "application"
+  subnets            = module.vpc.public_subnets
+  security_groups    = [aws_security_group.app.id]
+
+  tags = { Environment = var.environment }
+}
+
+resource "aws_lb_target_group" "backend" {
+  name        = "${var.environment}-api-tg"
+  port        = 5050
+  protocol    = "HTTP"
+  vpc_id      = module.vpc.vpc_id
+  target_type = "ip"
+}
+
+resource "aws_lb_listener" "backend_http" {
+  load_balancer_arn = aws_lb.backend.arn
+  port              = 80
+  protocol          = "HTTP"
+
+  default_action {
+    type             = "forward"
+    target_group_arn = aws_lb_target_group.backend.arn
+  }
+}
+
+# ECR リポジトリ
+resource "aws_ecr_repository" "backend" {
+  name = "backend"
+}
+resource "aws_ecr_repository" "frontend" {
+  name = "frontend"
+}
+
+# ECS クラスター
+resource "aws_ecs_cluster" "backend" {
+  name = "${var.environment}-api"
+}
+resource "aws_ecs_cluster" "frontend" {
+  name = "${var.environment}-front"
+}
+
+# RDS (PostgreSQL)
+resource "aws_db_subnet_group" "rds" {
+  name       = "${var.environment}-rds-subnet-group"
+  subnet_ids = module.vpc.private_subnets
+  tags = { Environment = var.environment }
+}
+resource "aws_db_instance" "rds" {
+  identifier              = "${var.environment}-db"
+  engine                  = "postgres"
+  instance_class          = var.db_instance_class
+  allocated_storage       = var.db_allocated_storage
+  username                = var.db_username
+  password                = var.db_password
+  db_name                 = var.db_name
+  db_subnet_group_name    = aws_db_subnet_group.rds.name
+  vpc_security_group_ids  = [aws_security_group.rds.id]
+  skip_final_snapshot     = true
+  publicly_accessible     = false
+  tags = { Environment = var.environment }
+}
+
+# SSM Parameter Store
+resource "aws_ssm_parameter" "api_base_url" {
+  name  = "/${var.environment}/api-base-url"
+  type  = "String"
+  value = var.api_base_url
+}
+
+# Secrets Manager (backend.env)
+resource "aws_secretsmanager_secret" "backend_env" {
+  name = "${var.environment}/backend/env"
+}
+resource "aws_secretsmanager_secret_version" "backend_env_version" {
+  secret_id     = aws_secretsmanager_secret.backend_env.id
+  secret_string = file("../../backend/.env.stg")
+} 

--- a/infrastructure/terraform/services.tf
+++ b/infrastructure/terraform/services.tf
@@ -1,0 +1,150 @@
+# ECS Task Definitions and Services for frontend & backend
+
+# Backend task definition
+resource "aws_ecs_task_definition" "backend" {
+  family                   = "${var.environment}-api"
+  network_mode             = "awsvpc"
+  requires_compatibilities = ["FARGATE"]
+  cpu                      = "256"
+  memory                   = "512"
+  execution_role_arn       = aws_iam_role.ecs_task_execution_role.arn
+  container_definitions    = jsonencode([
+    {
+      name      = "backend",
+      image     = "${aws_ecr_repository.backend.repository_url}:${var.environment}",
+      essential = true,
+      portMappings = [
+        { containerPort = 5050, protocol = "tcp" }
+      ],
+      # 環境変数は全て SSM パラメータから取得
+      secrets = [for param in aws_ssm_parameter.backend_env : {
+        name      = split("/", param.name)[3] # 各キー名を抽出
+        valueFrom = param.arn
+      }],
+      logConfiguration = {
+        logDriver = "awslogs"
+        options = {
+          awslogs-group         = "/ecs/${var.environment}-api"
+          awslogs-region        = var.aws_region
+          awslogs-stream-prefix = "ecs"
+        }
+      }
+    }
+  ])
+}
+
+# Backend service
+resource "aws_ecs_service" "backend" {
+  name            = "${var.environment}-api-service"
+  cluster         = aws_ecs_cluster.backend.id
+  task_definition = aws_ecs_task_definition.backend.arn
+  desired_count   = 1
+  launch_type     = "FARGATE"
+  platform_version = "LATEST"
+  network_configuration {
+    subnets         = module.vpc.public_subnets
+    security_groups = [aws_security_group.app.id]
+    assign_public_ip = true
+  }
+  load_balancer {
+    target_group_arn = aws_lb_target_group.backend.arn
+    container_name   = "backend"
+    container_port   = 5050
+  }
+  depends_on = [ aws_lb_listener.backend_http ]
+}
+
+# Frontend task definition
+resource "aws_ecs_task_definition" "frontend" {
+  family                   = "${var.environment}-front"
+  network_mode             = "awsvpc"
+  requires_compatibilities = ["FARGATE"]
+  cpu                      = "256"
+  memory                   = "512"
+  execution_role_arn       = aws_iam_role.ecs_task_execution_role.arn
+  container_definitions    = jsonencode([
+    {
+      name      = "frontend",
+      image     = "${aws_ecr_repository.frontend.repository_url}:${var.environment}",
+      essential = true,
+      portMappings = [
+        { containerPort = 3000, protocol = "tcp" }
+      ],
+      secrets = [
+        {
+          name      = "NEXT_PUBLIC_API_BASE_URL"
+          valueFrom = aws_ssm_parameter.api_base_url.arn
+        },
+        {
+          name      = "NEXT_PUBLIC_BROWSER_API_URL"
+          valueFrom = aws_ssm_parameter.api_base_url.arn
+        }
+      ],
+      logConfiguration = {
+        logDriver = "awslogs"
+        options = {
+          awslogs-group         = "/ecs/${var.environment}-front"
+          awslogs-region        = var.aws_region
+          awslogs-stream-prefix = "ecs"
+        }
+      }
+    }
+  ])
+}
+
+# Frontend service
+resource "aws_ecs_service" "frontend" {
+  name            = "${var.environment}-front-service"
+  cluster         = aws_ecs_cluster.frontend.id
+  task_definition = aws_ecs_task_definition.frontend.arn
+  desired_count   = 1
+  launch_type     = "FARGATE"
+  platform_version = "LATEST"
+  network_configuration {
+    subnets         = module.vpc.public_subnets
+    security_groups = [aws_security_group.app.id]
+    assign_public_ip = true
+  }
+  load_balancer {
+    target_group_arn = aws_lb_target_group.frontend.arn
+    container_name   = "frontend"
+    container_port   = 3000
+  }
+  depends_on = [ aws_lb_listener.frontend_http ]
+}
+
+# Variable for secrets used by backend
+variable "backend_secret_names" {
+  type    = list(string)
+  default = [
+    "DATABASE_URL",
+    "OPENAI_API_KEY",
+    "SECRET_KEY",
+    "STRIPE_SECRET_KEY",
+    "STRIPE_PUBLISHABLE_KEY",
+    "STRIPE_WEBHOOK_SECRET",
+    "NEXTAUTH_URL",
+    "AUTH_SECRET"
+  ]
+}
+
+# .env.stgをパースしてキー・値のマップを取得
+data "external" "dotenv" {
+  program = ["bash", "-c", <<-EOF
+    echo -n '{'
+    awk -F= '/^[A-Za-z0-9_]+=/{gsub(/"/,"\\\"",$2); printf "\"%s\":\"%s\",", $1, $2}' ../../backend/.env.stg | sed 's/,$//'
+    echo '}'
+EOF
+  ]
+}
+locals {
+  backend_env = data.external.dotenv.result
+}
+
+# SSMパラメータを for_each で自動作成
+resource "aws_ssm_parameter" "backend_env" {
+  for_each = local.backend_env
+  name     = "/${var.environment}/backend/${each.key}"
+  type     = "SecureString"
+  value    = each.value
+} 

--- a/infrastructure/terraform/variables.tf
+++ b/infrastructure/terraform/variables.tf
@@ -1,0 +1,59 @@
+variable "aws_region" {
+  type    = string
+  default = "ap-northeast-1"
+}
+
+variable "environment" {
+  type    = string
+  default = "stg"
+}
+
+variable "vpc_cidr" {
+  type    = string
+  default = "10.0.0.0/16"
+}
+
+variable "azs" {
+  type    = list(string)
+  default = ["ap-northeast-1a", "ap-northeast-1c"]
+}
+
+variable "public_subnets" {
+  type    = list(string)
+  default = ["10.0.1.0/24", "10.0.2.0/24"]
+}
+
+variable "private_subnets" {
+  type    = list(string)
+  default = ["10.0.101.0/24", "10.0.102.0/24"]
+}
+
+variable "db_instance_class" {
+  type    = string
+  default = "db.t3.micro"
+}
+
+variable "db_allocated_storage" {
+  type    = number
+  default = 20
+}
+
+variable "db_username" {
+  type    = string
+  default = "user"
+}
+
+variable "db_password" {
+  type = string
+  description = "password"
+}
+
+variable "db_name" {
+  type    = string
+  default = "demo"
+}
+
+variable "api_base_url" {
+  type        = string
+  description = "http://stg-api.smartao.com"
+} 

--- a/scripts/setup_infra.sh
+++ b/scripts/setup_infra.sh
@@ -1,0 +1,244 @@
+#!/usr/bin/env bash
+set -euxo pipefail
+
+# =================================================
+# AWS Free Tier 向けインフラ構築スクリプト
+# 実行前に AWS CLI が設定済みであることを確認してください。
+# =================================================
+
+# 環境変数
+AWS_REGION=ap-northeast-1
+AWS_ACCOUNT_ID=$(aws sts get-caller-identity --query Account --output text)
+VPC_CIDR=10.0.0.0/16
+
+# サブネットCIDR
+PUB_SUBNET1=10.0.1.0/24
+PUB_SUBNET2=10.0.2.0/24
+PRI_SUBNET1=10.0.101.0/24
+PRI_SUBNET2=10.0.102.0/24
+
+# RDS パラメータ
+DB_IDENTIFIER=smartao-stg-db
+DB_USER=user
+DB_PASS=password
+DB_NAME=demo
+DB_CLASS=db.t3.micro
+DB_STORAGE=20
+
+# SES ドメイン (検証に使う)
+SES_DOMAIN=example.com
+
+# =================================================
+# 1. VPC 作成
+# =================================================
+VPC_ID=$(aws ec2 create-vpc --cidr-block $VPC_CIDR --region $AWS_REGION \
+  --query 'Vpc.VpcId' --output text)
+aws ec2 modify-vpc-attribute --vpc-id $VPC_ID --enable-dns-hostnames --region $AWS_REGION
+aws ec2 create-tags --resources $VPC_ID --tags Key=Name,Value=smartao-stg-vpc --region $AWS_REGION
+
+echo "VPC_ID=${VPC_ID}"
+
+# =================================================
+# 2. Internet Gateway とルートテーブル
+# =================================================
+IGW_ID=$(aws ec2 create-internet-gateway --region $AWS_REGION --query 'InternetGateway.InternetGatewayId' --output text)
+aws ec2 attach-internet-gateway --vpc-id $VPC_ID --internet-gateway-id $IGW_ID --region $AWS_REGION
+RTB_ID=$(aws ec2 create-route-table --vpc-id $VPC_ID --region $AWS_REGION --query 'RouteTable.RouteTableId' --output text)
+aws ec2 create-route --route-table-id $RTB_ID --destination-cidr-block 0.0.0.0/0 --gateway-id $IGW_ID --region $AWS_REGION
+
+echo "IGW_ID=${IGW_ID}, RTB_ID=${RTB_ID}"
+
+# =================================================
+# 3. サブネット作成
+# =================================================
+SUBNET_PUB1=$(aws ec2 create-subnet --vpc-id $VPC_ID --cidr-block $PUB_SUBNET1 \
+  --availability-zone ${AWS_REGION}a --region $AWS_REGION \
+  --query 'Subnet.SubnetId' --output text)
+SUBNET_PUB2=$(aws ec2 create-subnet --vpc-id $VPC_ID --cidr-block $PUB_SUBNET2 \
+  --availability-zone ${AWS_REGION}c --region $AWS_REGION \
+  --query 'Subnet.SubnetId' --output text)
+
+# ルートテーブル関連付け (Public)
+aws ec2 associate-route-table --subnet-id $SUBNET_PUB1 --route-table-id $RTB_ID --region $AWS_REGION
+aws ec2 associate-route-table --subnet-id $SUBNET_PUB2 --route-table-id $RTB_ID --region $AWS_REGION
+
+echo "Public Subnets: $SUBNET_PUB1, $SUBNET_PUB2"
+
+# Private Subnet
+SUBNET_PRI1=$(aws ec2 create-subnet --vpc-id $VPC_ID --cidr-block $PRI_SUBNET1 \
+  --availability-zone ${AWS_REGION}a --region $AWS_REGION \
+  --query 'Subnet.SubnetId' --output text)
+SUBNET_PRI2=$(aws ec2 create-subnet --vpc-id $VPC_ID --cidr-block $PRI_SUBNET2 \
+  --availability-zone ${AWS_REGION}c --region $AWS_REGION \
+  --query 'Subnet.SubnetId' --output text)
+
+echo "Private Subnets: $SUBNET_PRI1, $SUBNET_PRI2"
+
+# =================================================
+# 4. セキュリティグループ作成
+# =================================================
+# アプリ用 SG
+SG_APP=$(aws ec2 create-security-group --group-name smartao-stg-app-sg \
+  --description "App SG" --vpc-id $VPC_ID --region $AWS_REGION \
+  --query 'GroupId' --output text)
+aws ec2 authorize-security-group-ingress --group-id $SG_APP \
+  --protocol tcp --port 3000 --cidr 0.0.0.0/0 --region $AWS_REGION
+aws ec2 authorize-security-group-ingress --group-id $SG_APP \
+  --protocol tcp --port 5050 --cidr 0.0.0.0/0 --region $AWS_REGION
+
+echo "SG_APP=${SG_APP}"
+
+# RDS 用 SG
+SG_RDS=$(aws ec2 create-security-group --group-name smartao-stg-rds-sg \
+  --description "RDS SG" --vpc-id $VPC_ID --region $AWS_REGION \
+  --query 'GroupId' --output text)
+aws ec2 authorize-security-group-ingress --group-id $SG_RDS \
+  --protocol tcp --port 5432 --source-group $SG_APP --region $AWS_REGION
+
+echo "SG_RDS=${SG_RDS}"
+
+# =================================================
+# Application Load Balancer の作成 (フロントエンド)
+# =================================================
+ALB_FRONT_ARN=$(aws elbv2 create-load-balancer \
+  --name smartao-front-stg-alb \
+  --subnets $SUBNET_PUB1 $SUBNET_PUB2 \
+  --security-groups $SG_APP \
+  --scheme internet-facing \
+  --type application \
+  --ip-address-type ipv4 \
+  --region $AWS_REGION \
+  --query 'LoadBalancers[0].LoadBalancerArn' \
+  --output text)
+echo "Front ALB ARN=${ALB_FRONT_ARN}"
+
+# フロントエンド用ターゲットグループ作成
+TG_FRONT_ARN=$(aws elbv2 create-target-group \
+  --name smartao-front-stg-tg \
+  --protocol HTTP \
+  --port 3000 \
+  --vpc-id $VPC_ID \
+  --target-type ip \
+  --region $AWS_REGION \
+  --query 'TargetGroups[0].TargetGroupArn' \
+  --output text)
+echo "Front TG ARN=${TG_FRONT_ARN}"
+
+# フロントエンド用リスナー作成 (ポート80)
+aws elbv2 create-listener \
+  --load-balancer-arn $ALB_FRONT_ARN \
+  --protocol HTTP \
+  --port 80 \
+  --default-actions Type=forward,TargetGroupArn=$TG_FRONT_ARN \
+  --region $AWS_REGION
+
+# =================================================
+# Application Load Balancer の作成 (バックエンド)
+# =================================================
+ALB_BACK_ARN=$(aws elbv2 create-load-balancer \
+  --name smartao-api-stg-alb \
+  --subnets $SUBNET_PUB1 $SUBNET_PUB2 \
+  --security-groups $SG_APP \
+  --scheme internet-facing \
+  --type application \
+  --ip-address-type ipv4 \
+  --region $AWS_REGION \
+  --query 'LoadBalancers[0].LoadBalancerArn' \
+  --output text)
+echo "Back ALB ARN=${ALB_BACK_ARN}"
+
+# バックエンド用ターゲットグループ作成
+TG_BACK_ARN=$(aws elbv2 create-target-group \
+  --name smartao-api-stg-tg \
+  --protocol HTTP \
+  --port 5050 \
+  --vpc-id $VPC_ID \
+  --target-type ip \
+  --region $AWS_REGION \
+  --query 'TargetGroups[0].TargetGroupArn' \
+  --output text)
+echo "Back TG ARN=${TG_BACK_ARN}"
+
+# バックエンド用リスナー作成 (ポート80)
+aws elbv2 create-listener \
+  --load-balancer-arn $ALB_BACK_ARN \
+  --protocol HTTP \
+  --port 80 \
+  --default-actions Type=forward,TargetGroupArn=$TG_BACK_ARN \
+  --region $AWS_REGION
+
+echo "ALBs and target groups created"
+
+# =================================================
+# 5. ECR リポジトリ作成
+# =================================================
+aws ecr create-repository --repository-name backend --region $AWS_REGION
+aws ecr create-repository --repository-name frontend --region $AWS_REGION
+
+echo "ECR repositories created"
+
+# =================================================
+# 6. ECS クラスター作成
+# =================================================
+aws ecs create-cluster --cluster-name smartao-api-stg --region $AWS_REGION
+aws ecs create-cluster --cluster-name smartao-front-stg --region $AWS_REGION
+
+echo "ECS clusters created"
+
+# =================================================
+# 7. RDS インスタンス作成
+# =================================================
+aws rds create-db-subnet-group \
+  --db-subnet-group-name smartao-stg-db-subnet-group \
+  --db-subnet-group-description "Subnet group for STG" \
+  --subnet-ids $SUBNET_PRI1 $SUBNET_PRI2 --region $AWS_REGION
+
+aws rds create-db-instance \
+  --db-instance-identifier $DB_IDENTIFIER \
+  --db-instance-class $DB_CLASS \
+  --engine postgres \
+  --allocated-storage $DB_STORAGE \
+  --master-username $DB_USER \
+  --master-user-password $DB_PASS \
+  --db-name $DB_NAME \
+  --db-subnet-group-name smartao-stg-db-subnet-group \
+  --vpc-security-group-ids $SG_RDS \
+  --no-publicly-accessible \
+  --region $AWS_REGION
+
+echo "RDS instance creation initiated"
+
+# =================================================
+# 8. SES ドメイン検証
+# =================================================
+aws ses verify-domain-identity --domain $SES_DOMAIN --region $AWS_REGION
+
+echo "SES domain verification requested: $SES_DOMAIN"
+
+# =================================================
+# 9. Parameter Store (例)
+# =================================================
+aws ssm put-parameter --name /smartao/stg/api-base-url --value https://stg-api.smartao.com --type String --overwrite --region $AWS_REGION
+
+echo "Parameter Store entry created"
+
+# =================================================
+# 10. Secrets Manager (例)
+# =================================================
+aws secretsmanager create-secret --name stg/backend/env --secret-string file://backend/.env.stg --region $AWS_REGION
+
+echo "Secrets Manager secret created"
+
+# =================================================
+# 11. IAM Role for ECS Task Execution
+# =================================================
+aws iam create-role --role-name ecsTaskExecutionRole-stg \
+  --assume-role-policy-document '{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":{"Service":"ecs-tasks.amazonaws.com"},"Action":"sts:AssumeRole"}]}' --region $AWS_REGION
+aws iam attach-role-policy --role-name ecsTaskExecutionRole-stg --policy-arn arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy --region $AWS_REGION
+aws iam attach-role-policy --role-name ecsTaskExecutionRole-stg --policy-arn arn:aws:iam::aws:policy/service-role/AmazonEC2ContainerRegistryPowerUser --region $AWS_REGION
+
+echo "IAM role ecsTaskExecutionRole-stg created"
+
+# =================================================
+# End of script
+# ================================================= 


### PR DESCRIPTION
This commit introduces a comprehensive setup for the staging environment using Terraform, including VPC, subnets, security groups, and ECS configurations for both backend and frontend applications. It also adds a new script for inserting demo data into the database via ECS Exec, enhancing the deployment process. Additionally, the README has been updated with instructions for demo data insertion on ECS.