### PR TITLE
Update CORS settings in main.py to include staging and production env…

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -85,8 +85,9 @@ app.add_middleware(
         "http://host.docker.internal:3000",  # Docker -> ホスト接続
         "http://host.docker.internal:5050",  # Docker -> ホスト接続
         "https://yourdomain.com",  # 本番環境（必要に応じて変更）
-        # すべてのオリジンを許可 - 開発時のみ使用
-        "*"
+        "https://stg.smartao.jp", # ステージング環境フロントエンド
+        "https://api.smartao.jp", # 本番環境API
+        "https://smartao.jp", # 本番環境フロントエンド
     ],
     allow_credentials=True,  # 認証情報を許可
     allow_methods=["*"],  # すべてのHTTPメソッドを許可


### PR DESCRIPTION
This pull request updates the CORS (Cross-Origin Resource Sharing) configuration in the `backend/app/main.py` file to restrict allowed origins to specific staging and production environments, improving security.

### CORS Configuration Update:
* Replaced the wildcard `"*"` (which allows all origins) with specific URLs for the staging environment (`https://stg.smartao.jp`), production API (`https://api.smartao.jp`), and production frontend (`https://smartao.jp`). This change ensures that only trusted origins can access the backend, enhancing security.