### PR TITLE
Update ECS task definition for production by changing the log group n…

### DIFF
--- a/AWS/backend-task-def-prod.json
+++ b/AWS/backend-task-def-prod.json
@@ -13,7 +13,7 @@
       "logConfiguration": {
         "logDriver": "awslogs",
         "options": {
-          "awslogs-group": "/ecs/backend-prod",
+          "awslogs-group": "/ecs/prod-api",
           "awslogs-region": "ap-northeast-1",
           "awslogs-stream-prefix": "ecs"
         }


### PR DESCRIPTION
…ame from '/ecs/backend-prod' to '/ecs/prod-api' to align with the new naming convention.